### PR TITLE
add blog to jekyll docs

### DIFF
--- a/docs/jekyll.qmd
+++ b/docs/jekyll.qmd
@@ -14,3 +14,4 @@ The following science blogs use Jekyll as a platform:
 
 * [Martin Paul Eve](https://eve.gd/)
 * [Journal of Open Source Software Blog](https://blog.joss.theoj.org/)
+* [Bastian Greshake Tzovaras](https://tzovar.as/)


### PR DESCRIPTION
I was just reading over the docs for different blogs and saw that those are manually maintained, so thought I'd propose adding my own to the list 🙂 